### PR TITLE
Improve CLI help, version display, and add retry for Douyin API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .env
 __pycache__/
 *.egg-info/
+.claude
+.claude-flow
+.swarm

--- a/src/parsehub/cli.py
+++ b/src/parsehub/cli.py
@@ -71,7 +71,9 @@ def _build_parser(prog: str) -> argparse.ArgumentParser:
             "  parsehub set cookie xhs"
         ),
     )
-    parser.add_argument("-v", "--version", action="version", version=f"parsehub {_package_version()}", help="显示当前版本")
+    parser.add_argument(
+        "-v", "--version", action="version", version=f"parsehub {_package_version()}", help="显示当前版本"
+    )
     subparsers = parser.add_subparsers(dest="command", metavar="command", required=True)
 
     parse_parser = subparsers.add_parser(

--- a/src/parsehub/cli.py
+++ b/src/parsehub/cli.py
@@ -6,6 +6,7 @@ import json
 import sys
 import unicodedata
 from dataclasses import asdict, is_dataclass
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -86,6 +87,7 @@ def _build_parser(prog: str) -> argparse.ArgumentParser:
             "  parsehub set cookie xhs"
         ),
     )
+    parser.add_argument("-v", "--version", action="version", version=f"parsehub {_package_version()}")
     subparsers = parser.add_subparsers(dest="command", metavar="命令", required=True)
 
     parse_parser = subparsers.add_parser(
@@ -142,6 +144,13 @@ def _build_parser(prog: str) -> argparse.ArgumentParser:
     _add_set_commands(subparsers)
 
     return parser
+
+
+def _package_version() -> str:
+    try:
+        return version("parsehub")
+    except PackageNotFoundError:
+        return "unknown"
 
 
 def _add_set_commands(subparsers: argparse._SubParsersAction) -> None:

--- a/src/parsehub/cli.py
+++ b/src/parsehub/cli.py
@@ -23,7 +23,7 @@ class _ChineseArgumentParser(argparse.ArgumentParser):
         add_help = kwargs.pop("add_help", True)
         super().__init__(*args, add_help=False, **kwargs)
         if add_help:
-            self.add_argument("-h", "--help", action="help", default=argparse.SUPPRESS, help="显示帮助信息并退出")
+            self.add_argument("-h", "--help", action="help", default=argparse.SUPPRESS, help="显示帮助信息")
 
     def error(self, message: str) -> None:
         self.print_usage(sys.stderr)
@@ -71,7 +71,7 @@ def _build_parser(prog: str) -> argparse.ArgumentParser:
             "  parsehub set cookie xhs"
         ),
     )
-    parser.add_argument("-v", "--version", action="version", version=f"parsehub {_package_version()}")
+    parser.add_argument("-v", "--version", action="version", version=f"parsehub {_package_version()}", help="显示当前版本")
     subparsers = parser.add_subparsers(dest="command", metavar="command", required=True)
 
     parse_parser = subparsers.add_parser(

--- a/src/parsehub/cli.py
+++ b/src/parsehub/cli.py
@@ -16,29 +16,13 @@ _COMMANDS = {"parse", "p", "download", "d", "dl", "platforms", "ls", "set"}
 _CLI_EXTRA_MODULES = ("argcomplete", "platformdirs")
 
 
-class _ChineseHelpFormatter(argparse.RawDescriptionHelpFormatter):
-    def start_section(self, heading: str | None) -> None:
-        headings = {
-            "positional arguments": "位置参数",
-            "options": "选项",
-            "optional arguments": "选项",
-        }
-        super().start_section(headings.get(heading, heading))
-
-
 class _ChineseArgumentParser(argparse.ArgumentParser):
     def __init__(self, *args: Any, **kwargs: Any):
-        kwargs.setdefault("formatter_class", _ChineseHelpFormatter)
+        kwargs.setdefault("formatter_class", argparse.RawDescriptionHelpFormatter)
         add_help = kwargs.pop("add_help", True)
         super().__init__(*args, add_help=False, **kwargs)
         if add_help:
             self.add_argument("-h", "--help", action="help", default=argparse.SUPPRESS, help="显示帮助信息并退出")
-
-    def format_usage(self) -> str:
-        return super().format_usage().replace("usage:", "用法:", 1)
-
-    def format_help(self) -> str:
-        return super().format_help().replace("usage:", "用法:", 1)
 
     def error(self, message: str) -> None:
         self.print_usage(sys.stderr)
@@ -86,7 +70,7 @@ def _build_parser(prog: str) -> argparse.ArgumentParser:
             "  parsehub set cookie xhs"
         ),
     )
-    subparsers = parser.add_subparsers(dest="command", metavar="命令", required=True)
+    subparsers = parser.add_subparsers(dest="command", metavar="command", required=True)
 
     parse_parser = subparsers.add_parser(
         "parse",
@@ -158,7 +142,7 @@ def _add_set_commands(subparsers: argparse._SubParsersAction) -> None:
             "  parsehub set cookie xhs"
         ),
     )
-    set_subparsers = set_parser.add_subparsers(dest="set_command", metavar="设置命令", required=True)
+    set_subparsers = set_parser.add_subparsers(dest="set_command", metavar="command", required=True)
 
     list_parser = set_subparsers.add_parser(
         "list",
@@ -599,8 +583,6 @@ def _translate_argparse_error(message: str) -> str:
         "unrecognized arguments:": "无法识别的参数:",
         "invalid choice:": "无效选择:",
         "expected one argument": "需要一个参数",
-        "argument 命令: invalid choice:": "未知命令:",
-        "argument 设置命令: invalid choice:": "未知设置命令:",
     }
     for source, target in replacements.items():
         message = message.replace(source, target)

--- a/src/parsehub/provider_api/douyin.py
+++ b/src/parsehub/provider_api/douyin.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import hashlib
 import random
@@ -8,6 +9,8 @@ from urllib.parse import quote, urlencode
 
 import httpx
 from gmssl import func, sm3
+
+from parsehub import ParseError
 
 DEFAULT_USER_AGENT = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
@@ -755,11 +758,17 @@ class DouyinWebCrawler:
                 "effective_type": "4g",
                 "aweme_id": aweme_id,
             }
-            a_bogus = ABogus().get_value(params)
-            endpoint = f"{POST_DETAIL}?{urlencode(params)}&a_bogus={quote(a_bogus, safe='')}"
-            response = await client.get(endpoint)
-            response.raise_for_status()
-            return response.json()
+            for attempt in range(3):
+                try:
+                    a_bogus = ABogus().get_value(params)
+                    endpoint = f"{POST_DETAIL}?{urlencode(params)}&a_bogus={quote(a_bogus, safe='')}"
+                    response = await client.get(endpoint)
+                    response.raise_for_status()
+                    return response.json()
+                except Exception:
+                    if attempt + 1 < 3:
+                        await asyncio.sleep(1)
+            raise ParseError("获取抖音作品失败, 请检查 cookie")
 
     async def parse(self, url: str) -> dict:
         aweme_id = await self.get_aweme_id(url)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -160,7 +160,7 @@ class TestCli(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertEqual(stderr, "")
         self.assertIn("ParseHub 命令行工具", stdout)
-        self.assertIn("用法:", stdout)
+        self.assertIn("usage:", stdout)
 
     def test_parse_defaults_to_human_readable_chinese_summary(self):
         with patch.object(cli, "_new_parsehub", FakeParseHub):
@@ -447,13 +447,14 @@ class TestCli(unittest.TestCase):
         self.assertIn("错误", stderr)
         self.assertIn("提示", stderr)
 
-    def test_top_level_help_uses_chinese_labels_and_examples(self):
+    def test_top_level_help_uses_english_cli_terms_and_chinese_examples(self):
         code, stdout, stderr = self.run_cli(["--help"])
 
         self.assertEqual(code, 0)
         self.assertEqual(stderr, "")
-        self.assertIn("用法:", stdout)
-        self.assertIn("位置参数", stdout)
+        self.assertIn("usage:", stdout)
+        self.assertIn("positional arguments", stdout)
+        self.assertIn("options", stdout)
         self.assertIn("常用示例", stdout)
         self.assertIn("parsehub set proxy xhs", stdout)
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -154,6 +154,38 @@ class TestCli(unittest.TestCase):
         self.assertIn('pip install "parsehub[cli]"', stderr.getvalue())
         build_parser.assert_not_called()
 
+    def test_missing_cli_extra_blocks_version_option(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with (
+            patch.object(cli, "_has_cli_extra_dependencies", return_value=False),
+            patch.object(cli, "_build_parser") as build_parser,
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+        ):
+            code = cli.main(["--version"])
+
+        self.assertEqual(code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("未安装 ParseHub CLI 扩展依赖", stderr.getvalue())
+        build_parser.assert_not_called()
+
+    def test_version_option_prints_package_version(self):
+        with patch.object(cli, "_package_version", return_value="9.9.9"):
+            code, stdout, stderr = self.run_cli(["--version"])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(stdout, "parsehub 9.9.9\n")
+        self.assertEqual(stderr, "")
+
+    def test_short_version_option_prints_package_version(self):
+        with patch.object(cli, "_package_version", return_value="9.9.9"):
+            code, stdout, stderr = self.run_cli(["-v"])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(stdout, "parsehub 9.9.9\n")
+        self.assertEqual(stderr, "")
+
     def test_empty_args_print_help(self):
         code, stdout, stderr = self.run_cli([])
 


### PR DESCRIPTION
---

### Summary

This pull request includes multiple updates and fixes to improve the command-line interface (CLI) and enhance error handling for external APIs like Douyin. 

### Changes Made
- **CLI Improvements**:  
  - Adjusted help option phrasing, streamlining the text and ensuring clarity in version outputs.
  - Restored English meta-terms (e.g., 'usage', 'options') within `argparse` CLI help while maintaining business-specific messages in Chinese.
  - Introduced a new `-v`/`--version` option for easier inspection of the installed ParseHub CLI version.

- **Douyin API Fix**:  
  - Added a retry mechanism for the Douyin work details API to handle intermittent network or service failures.

### Checklist
- [ ] Tests added for new features
- [ ] Documentation updated where applicable
- [ ] Validated against affected external dependencies

## Summary by Sourcery

改进 CLI 帮助输出语言，新增版本标志，并通过重试与更清晰的错误信息来强化抖音视频获取功能。

New Features:
- 新增 `-v/--version` CLI 选项，用于显示已安装的 `parsehub` 包版本。
- 引入一个辅助方法，用于在包元数据缺失时，仍能带有回退逻辑地解析 `parsehub` 包版本。

Bug Fixes:
- 为抖音作品详情 API 请求增加重试机制；当多次重试仍失败时，抛出清晰的 `ParseError`，而非直接向上抛出原始 HTTP 错误。

Enhancements:
- 统一 `argparse` 的 help 和 usage 输出，使用英文元术语，同时保留中文业务文案。
- 更新 CLI 子命令标签和错误翻译映射，使其与新的 `argparse` 术语保持一致。

Tests:
- 扩展 CLI 测试覆盖范围，增加对版本标志行为、缺失 CLI 依赖项处理以及更新后帮助输出预期的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve CLI help output language, add a version flag, and harden Douyin video fetching with retries and clearer failures.

New Features:
- Add -v/--version CLI option to display the installed parsehub package version.
- Introduce a helper to resolve the parsehub package version with a fallback when the package metadata is missing.

Bug Fixes:
- Retry Douyin work details API requests and surface a clear ParseError when repeated attempts fail instead of bubbling raw HTTP errors.

Enhancements:
- Standardize argparse help and usage output to use English meta-terms while keeping Chinese business messaging.
- Update CLI subcommand labels and error translation mappings to align with the new argparse terminology.

Tests:
- Extend CLI test coverage for version flag behavior, missing CLI extras handling, and updated help output expectations.

</details>