### PR TITLE
fix: support Weibo mapp fx links

### DIFF
--- a/src/parsehub/parsers/parser/weibo.py
+++ b/src/parsehub/parsers/parser/weibo.py
@@ -17,7 +17,7 @@ from ..base.base import BaseParser
 class WeiboParser(BaseParser):
     __platform__ = Platform.WEIBO
     __supported_type__ = ["视频", "图文"]
-    __match__ = r"^(http(s)?://)(m\.|)weibo.(com|cn)/(?!(u/)).+"
+    __match__ = r"^(http(s)?://)((m\.|)weibo\.(com|cn)/(?!(u/)).+|mapp\.api\.weibo\.cn/fx/.+)"
 
     async def _do_parse(self, raw_url: str) -> MultimediaParseResult | VideoParseResult | ImageParseResult:
         weibo = await WeiboAPI(self.proxy).parse(raw_url)

--- a/src/parsehub/provider_api/weibo.py
+++ b/src/parsehub/provider_api/weibo.py
@@ -1,15 +1,20 @@
 import abc
 import asyncio
+import re
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from inspect import signature
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
 
 class WeiboAPI:
+    _MAPP_FX_NETLOC = "mapp.api.weibo.cn"
+    _STATUS_PATH_PATTERN = re.compile(r"^/status/([^/?#]+)")
+
     def __init__(self, proxy: str | None = None):
         self.proxy = proxy
 
@@ -20,8 +25,26 @@ class WeiboAPI:
             return bid
         return None
 
+    async def resolve_url(self, url: str) -> str:
+        parsed = urlparse(url)
+        if parsed.hostname != self._MAPP_FX_NETLOC or not parsed.path.startswith("/fx/"):
+            return url
+
+        async with httpx.AsyncClient(proxy=self.proxy, follow_redirects=False, timeout=30) as client:
+            response = await client.get(url)
+            if response.is_error:
+                response.raise_for_status()
+        return response.headers.get("location") or url
+
+    async def get_id_by_url_async(self, url: str) -> str | None:
+        url = await self.resolve_url(url)
+        parsed = urlparse(url)
+        if match := self._STATUS_PATH_PATTERN.match(parsed.path):
+            return match.group(1)
+        return self.get_id_by_url(url)
+
     async def parse(self, url: str) -> "WeiboContent":
-        bid = self.get_id_by_url(url)
+        bid = await self.get_id_by_url_async(url)
         if not bid:
             raise ValueError("Invalid URL")
         headers = {


### PR DESCRIPTION
### Summary

This pull request fixes Weibo `mapp.api.weibo.cn/fx/...` share links not being recognized by ParseHub.

These links first redirect to a usable `m.weibo.cn/status/...` URL, but ParseHub selects a parser before resolving redirects. As a result, the original share link was treated as an unknown platform while the redirected status URL could be parsed.

### Changes Made

- **Weibo URL Matching**
  - Added support for `https://mapp.api.weibo.cn/fx/...` links in `WeiboParser`.

- **Weibo Redirect Handling**
  - Added first-hop resolution for Weibo `mapp.api.weibo.cn/fx/...` links.
  - Extracts the status ID from the first redirected `m.weibo.cn/status/<id>` URL.

## 由 Sourcery 提供的摘要

为来自 `mapp.api.weibo.cn/fx`、并重定向到微博状态链接的分享地址，新增解析与解析支持。

新功能：
- 在微博解析器中，支持解析 `mapp.api.weibo.cn/fx` 的微博分享链接。

错误修复：
- 确保那些会先重定向到 `m.weibo.cn/status` 的微博分享链接，能够被正确解析为微博状态，而不是被当作未知链接处理。

增强功能：
- 在微博 API 中引入异步 URL 解析机制，在解析前先从重定向后的微博链接中提取状态 ID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for resolving and parsing Weibo share links from mapp.api.weibo.cn/fx that redirect to status URLs.

New Features:
- Support parsing Weibo mapp.api.weibo.cn/fx share URLs in the Weibo parser.

Bug Fixes:
- Ensure Weibo share links that first redirect to m.weibo.cn/status URLs are correctly resolved and parsed instead of being treated as unknown.

Enhancements:
- Introduce asynchronous URL resolution in the Weibo API to extract status IDs from redirected Weibo URLs before parsing.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

为来自 `mapp.api.weibo.cn/fx`、并重定向到微博状态链接的分享地址，新增解析与解析支持。

新功能：
- 在微博解析器中，支持解析 `mapp.api.weibo.cn/fx` 的微博分享链接。

错误修复：
- 确保那些会先重定向到 `m.weibo.cn/status` 的微博分享链接，能够被正确解析为微博状态，而不是被当作未知链接处理。

增强功能：
- 在微博 API 中引入异步 URL 解析机制，在解析前先从重定向后的微博链接中提取状态 ID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for resolving and parsing Weibo share links from mapp.api.weibo.cn/fx that redirect to status URLs.

New Features:
- Support parsing Weibo mapp.api.weibo.cn/fx share URLs in the Weibo parser.

Bug Fixes:
- Ensure Weibo share links that first redirect to m.weibo.cn/status URLs are correctly resolved and parsed instead of being treated as unknown.

Enhancements:
- Introduce asynchronous URL resolution in the Weibo API to extract status IDs from redirected Weibo URLs before parsing.

</details>

</details>