### PR TITLE
feat(threads): rebuild extractor on GraphQL with cookie auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ print(result)
 
 - `Twitter / X`
 - `Instagram`
+- `Threads`
 - `YouTube`
 - `Bilibili`
 - `抖音`

--- a/src/parsehub/parsers/parser/threads.py
+++ b/src/parsehub/parsers/parser/threads.py
@@ -1,5 +1,5 @@
-from ...provider_api.threads import ThreadsAPI, ThreadsMedia, ThreadsMediaType
-from ...types import AnyMediaRef, ImageRef, MultimediaParseResult, Platform, VideoRef
+from ...provider_api.threads import ThreadsAPI, ThreadsAPIError, ThreadsMedia, ThreadsMediaType, ThreadsPost
+from ...types import AnyMediaRef, ImageRef, MultimediaParseResult, ParseError, Platform, VideoRef
 from ..base.base import BaseParser
 
 
@@ -9,7 +9,7 @@ class ThreadsParser(BaseParser):
     __match__ = r"^(http(s)?://)?.+threads.com/@[\w.]+/post/.*"
 
     async def _do_parse(self, raw_url: str) -> "MultimediaParseResult":
-        post = await ThreadsAPI(proxy=self.proxy).parse(raw_url)
+        post = await self._parse(raw_url)
         media: list[AnyMediaRef] = []
         if post.media:
             pm: list[ThreadsMedia] = post.media if isinstance(post.media, list) else [post.media]
@@ -20,6 +20,20 @@ class ThreadsParser(BaseParser):
                     case ThreadsMediaType.IMAGE:
                         media.append(ImageRef(url=m.url, thumb_url=m.url, width=m.width, height=m.height))
         return MultimediaParseResult(content=post.content, media=media)
+
+    async def _parse(self, url: str) -> ThreadsPost:
+        # 公开帖子无需登录即可解析; 登录墙内容 (私密/受限/年龄限制) 才需要 Cookie, 有则带上
+        try:
+            api = ThreadsAPI(proxy=self.proxy, cookie=self.cookie.get_value() if self.cookie else None)
+            return await api.parse(url)
+        except ThreadsAPIError as e:
+            if not self.cookie:
+                raise ParseError("无法获取帖子内容: 该帖子可能位于登录墙内, 请为 threads 平台配置 Cookie") from e
+            raise ParseError("无法获取帖子内容(可能为私人或受限内容, 或 Cookie 已失效)") from e
+        except ParseError:
+            raise
+        except Exception as e:
+            raise ParseError(f"无法获取帖子内容: {e}") from e
 
 
 __all__ = ["ThreadsParser"]

--- a/src/parsehub/provider_api/threads.py
+++ b/src/parsehub/provider_api/threads.py
@@ -1,45 +1,186 @@
 from __future__ import annotations
 
 import json
-import random
 import re
-import string
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 import httpx
 
 from ..utils.helpers import UA
 
 
+class ThreadsAPIError(Exception):
+    """Threads API 相关错误"""
+
+
 class ThreadsAPI:
-    def __init__(self, proxy: str | None = None):
+    GRAPHQL_URL = "https://www.threads.com/graphql/query"
+    THREADS_URL = "https://www.threads.com/"
+    # BarcelonaPostPageDirectQuery, 通过帖子 ID 获取帖子内容
+    POST_DOC_ID = "27419285281047858"
+    X_IG_APP_ID = "238260118697367"
+    # shortcode <-> pk 使用与 Instagram 相同的 base64 字母表
+    SHORTCODE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+
+    # Threads 与 Instagram 共用 Meta 的登录后端, 因此使用同一套 Cookie 键
+    DEFAULT_COOKIES = {
+        "sessionid": "",
+        "ds_user_id": "",
+        "csrftoken": "",
+        "mid": "",
+        "ig_did": "",
+    }
+
+    # GraphQL 查询强制要求的 relay provider 变量: 必须全部传入 (值统一给 False 即可),
+    # 缺失或只传部分都会导致查询返回 execution error.
+    # 与 Instagram 的 doc_id 一样, 该列表会随 Threads 前端更新而变化, 需要时同步维护.
+    RELAY_PROVIDERS = (
+        "BarcelonaHasPermalinkIndentation",
+        "BarcelonaIsLoggedIn",
+        "BarcelonaHasPostAuthorNotifControls",
+        "BarcelonaShouldShowFediverseM1Features",
+        "BarcelonaHasPermalinkPodcastCard",
+        "BarcelonaHasDearAlgoConsumption",
+        "BarcelonaHasEventBadge",
+        "BarcelonaGenAIRepliesEnabled",
+        "BarcelonaIsSearchDiscoveryEnabled",
+        "BarcelonaHasCommunities",
+        "BarcelonaHasGameScoreShare",
+        "BarcelonaHasPublicViewCountCard",
+        "BarcelonaHasCommunityEntityCard",
+        "BarcelonaHasScorecardCommunity",
+        "BarcelonaHasSportTeamAllegianceCard",
+        "BarcelonaHasMusic",
+        "BarcelonaHasNewspaperLinkStyle",
+        "BarcelonaHasMessaging",
+        "BarcelonaHasPodcastTextFragments",
+        "BarcelonaShouldFulfillLightboxQuery",
+        "BarcelonaHasViewerReplied",
+        "BarcelonaHasPrivateRepliesDeprecation",
+        "BarcelonaHasGhostPostEmojiActivation",
+        "BarcelonaOptionalCookiesEnabled",
+        "BarcelonaHasDearAlgoWebProduction",
+        "BarcelonaHasWebFavicons",
+        "BarcelonaIsCrawler",
+        "BarcelonaHasCommunityTopContributors",
+        "BarcelonaCanSeeSponsoredContent",
+        "BarcelonaShouldShowFediverseM075Features",
+        "BarcelonaIsInternalUser",
+    )
+
+    def __init__(
+        self,
+        proxy: str | None = None,
+        cookie: dict[str, str] | None = None,
+        timeout: float = 30,
+    ):
         self.proxy = proxy
+        self.cookie = cookie or {}
+        self.timeout = timeout
 
     async def parse(self, url: str) -> ThreadsPost:
-        lsd = self.random_lsd()
+        code = self.get_post_id_by_url(url)
+        payload = await self._post_graphql(
+            doc_id=self.POST_DOC_ID,
+            variables=self._build_variables(code),
+        )
+        post = self._extract_post(payload, code)
+        if post is None:
+            raise ThreadsAPIError("Fetching Post metadata failed.")
+        return ThreadsPost.from_graphql(post)
+
+    def _build_variables(self, code: str) -> dict[str, Any]:
+        variables: dict[str, Any] = {"postID": str(self.shortcode_to_pk(code))}
+        for name in self.RELAY_PROVIDERS:
+            variables[f"__relay_internal__pv__{name}relayprovider"] = False
+        return variables
+
+    async def _post_graphql(self, *, doc_id: str, variables: dict[str, Any]) -> dict[str, Any]:
+        async with self._new_client() as client:
+            await self._ensure_csrf_token(client)
+            data = {
+                "variables": json.dumps(variables, separators=(",", ":")),
+                "doc_id": doc_id,
+                "server_timestamps": "true",
+            }
+            try:
+                response = await client.post(self.GRAPHQL_URL, data=data, follow_redirects=False)
+            except httpx.HTTPError as exc:
+                raise ThreadsAPIError(f"请求 Threads GraphQL 失败: {exc}") from exc
+
+        if response.status_code != 200:
+            raise ThreadsAPIError(f"Threads GraphQL 返回 HTTP {response.status_code}: {response.text[:500]}")
+
+        try:
+            payload: dict[str, Any] = response.json()
+        except ValueError as exc:
+            # 未登录时会返回 HTML 登录页
+            raise ThreadsAPIError("Threads GraphQL 返回非 JSON 响应(可能需要登录)") from exc
+
+        if payload.get("errors"):
+            raise ThreadsAPIError(f"Threads GraphQL 返回错误: {payload['errors']}")
+        return payload
+
+    @staticmethod
+    def _extract_post(payload: dict[str, Any], code: str) -> dict[str, Any] | None:
+        data = ((payload.get("data") or {}).get("data")) or {}
+        edges = data.get("edges") or []
+        fallback: dict[str, Any] | None = None
+        for edge in edges:
+            for item in (edge.get("node") or {}).get("thread_items") or []:
+                post = item.get("post")
+                if not isinstance(post, dict):
+                    continue
+                if fallback is None:
+                    fallback = post
+                if post.get("code") == code:
+                    return post
+        # 找不到精确匹配时退回第一条 (通常即目标帖子本身)
+        return fallback
+
+    def _new_client(self) -> httpx.AsyncClient:
+        cookies = self.DEFAULT_COOKIES | self.cookie
         headers = {
-            "content-type": "application/x-www-form-urlencoded",
-            "sec-fetch-site": "same-origin",
-            "user-agent": UA,
-            "x-fb-lsd": lsd,
+            "Accept": "*/*",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Referer": self.THREADS_URL,
+            "User-Agent": UA,
+            "X-IG-App-ID": self.X_IG_APP_ID,
         }
+        return httpx.AsyncClient(
+            cookies=cookies,
+            headers=headers,
+            proxy=self.proxy,
+            timeout=self.timeout,
+        )
 
-        data = {
-            "route_url": f"/{self.get_username_by_url(url)}/post/{self.get_post_id_by_url(url)}/media",
-            "routing_namespace": "barcelona_web",
-            "__user": "0",
-            "__a": "1",
-            "__req": "m",
-            "__comet_req": "29",
-            "lsd": lsd,
-        }
+    async def _ensure_csrf_token(self, client: httpx.AsyncClient) -> None:
+        csrf_token = self._get_cookie_value(client, "csrftoken")
+        if not csrf_token:
+            try:
+                await client.get(self.THREADS_URL, follow_redirects=True)
+            except httpx.HTTPError as exc:
+                raise ThreadsAPIError(f"获取 Threads csrftoken 失败: {exc}") from exc
+            csrf_token = self._get_cookie_value(client, "csrftoken")
+        if csrf_token:
+            client.headers["x-csrftoken"] = csrf_token
 
-        async with httpx.AsyncClient(proxy=self.proxy) as client:
-            response = await client.post("https://www.threads.com/ajax/route-definition", headers=headers, data=data)
-            response.raise_for_status()
-            jsonp = [json.loads(j.strip()) for j in response.text.strip().split("for (;;);") if j]
-            return ThreadsPost.parse(jsonp)
+    @staticmethod
+    def _get_cookie_value(client: httpx.AsyncClient, name: str) -> str:
+        values = [cookie.value for cookie in client.cookies.jar if cookie.name == name and cookie.value]
+        return values[-1] if values else ""
+
+    @classmethod
+    def shortcode_to_pk(cls, code: str) -> int:
+        pk = 0
+        for ch in code:
+            try:
+                pk = pk * 64 + cls.SHORTCODE_ALPHABET.index(ch)
+            except ValueError as exc:
+                raise ValueError(f"无效的 Threads 帖子 ID: {code}") from exc
+        return pk
 
     @staticmethod
     def get_username_by_url(url: str) -> str:
@@ -54,10 +195,6 @@ class ThreadsAPI:
         if not p:
             raise ValueError("从 URL 中获取帖子 ID 失败")
         return p[1]
-
-    @staticmethod
-    def random_lsd() -> str:
-        return "".join(random.sample(string.ascii_letters + string.digits, 11))
 
 
 class ThreadsMediaType(Enum):
@@ -80,95 +217,71 @@ class ThreadsPost:
     media: ThreadsMedia | list[ThreadsMedia] | None = None
 
     @classmethod
-    def parse(cls, jsonp: list[dict]) -> ThreadsPost:
-        content = ""
-        media: ThreadsMedia | list[ThreadsMedia] | None = []
-        for j in jsonp:
-            match j["__type"]:
-                case "first_response":
-                    content = cls._fetch_content(j)
-                case "preloader":
-                    if "BarcelonaLightboxDialogRootQueryRelayPreloader" in (j.get("id") or ""):
-                        media = cls._fetch_media(j)
-                case "last_response":
-                    ...
-        return cls(content=content, media=media)
+    def from_graphql(cls, post: dict[str, Any]) -> ThreadsPost:
+        caption = post.get("caption")
+        content = caption.get("text") if isinstance(caption, dict) else caption
+        return cls(content=str(content or ""), media=cls._fetch_media(post))
 
-    @staticmethod
-    def _fetch_content(data: dict) -> str:
-        payload = data["payload"]
-        result = payload.get("result", {})
-        # 尝试从 redirect_result 获取（用户更改名称后的情况）
-        meta = result.get("redirect_result", {}).get("exports", {}).get("meta")
-        # 如果没有 redirect_result，则从正常路径获取
-        if not meta:
-            meta = result.get("exports", {}).get("meta")
-        if not meta:
-            raise Exception("获取内容失败")
-        return str(meta["title"])
-
-    @staticmethod
-    def _fetch_media(data: dict) -> ThreadsMedia | list[ThreadsMedia]:
-        data = data.get("result", {}).get("result", {}).get("data", {}).get("data")
-        if not data:
-            return []
-
-        def fn(d: dict) -> ThreadsMedia | list[ThreadsMedia]:
-            media: ThreadsMedia | list[ThreadsMedia]
-            match d["media_type"]:
-                case 1:  # 单张图片
-                    image = d["image_versions2"]["candidates"][0]
-                    media = ThreadsMedia(
-                        type=ThreadsMediaType.IMAGE,
-                        url=image["url"],
-                        thumb_url=image["url"],
-                        width=image["width"],
-                        height=image["height"],
-                    )
-                case 2:  # 单个视频
-                    thumb = d["image_versions2"]["candidates"][0]["url"]
-                    video = d["video_versions"][0]["url"]
-                    media = ThreadsMedia(
-                        type=ThreadsMediaType.VIDEO,
-                        url=video,
-                        thumb_url=thumb,
-                        width=d["original_width"],
-                        height=d["original_height"],
-                    )
-                case 8:  # 多图/视频
-                    carousel_media = d["carousel_media"]
-                    media = []
-                    for m in carousel_media:
-                        if m["video_versions"]:
-                            thumb = m["image_versions2"]["candidates"][0]["url"]
-                            video = m["video_versions"][0]["url"]
-                            media.append(
-                                ThreadsMedia(
-                                    type=ThreadsMediaType.VIDEO,
-                                    url=video,
-                                    thumb_url=thumb,
-                                    width=m["original_width"],
-                                    height=m["original_height"],
-                                )
+    @classmethod
+    def _fetch_media(cls, d: dict[str, Any]) -> ThreadsMedia | list[ThreadsMedia]:
+        media: ThreadsMedia | list[ThreadsMedia]
+        match d.get("media_type"):
+            case 1:  # 单张图片
+                image = d["image_versions2"]["candidates"][0]
+                media = ThreadsMedia(
+                    type=ThreadsMediaType.IMAGE,
+                    url=image["url"],
+                    thumb_url=image["url"],
+                    width=image.get("width", 0),
+                    height=image.get("height", 0),
+                )
+            case 2:  # 单个视频
+                thumb = d["image_versions2"]["candidates"][0]["url"]
+                video = d["video_versions"][0]["url"]
+                media = ThreadsMedia(
+                    type=ThreadsMediaType.VIDEO,
+                    url=video,
+                    thumb_url=thumb,
+                    width=d.get("original_width", 0),
+                    height=d.get("original_height", 0),
+                )
+            case 8:  # 多图/视频
+                media = []
+                for m in d.get("carousel_media") or []:
+                    if m.get("video_versions"):
+                        thumb = m["image_versions2"]["candidates"][0]["url"]
+                        media.append(
+                            ThreadsMedia(
+                                type=ThreadsMediaType.VIDEO,
+                                url=m["video_versions"][0]["url"],
+                                thumb_url=thumb,
+                                width=m.get("original_width", 0),
+                                height=m.get("original_height", 0),
                             )
-                        else:
-                            image = m["image_versions2"]["candidates"][0]["url"]
-                            media.append(
-                                ThreadsMedia(
-                                    type=ThreadsMediaType.IMAGE,
-                                    url=image,
-                                    thumb_url=image,
-                                    width=m["original_width"],
-                                    height=m["original_height"],
-                                )
-                            )
-                case 19:  # 纯文本/外部链接
-                    if linked_inline_media := d["text_post_app_info"]["linked_inline_media"]:
-                        media = fn(linked_inline_media)
+                        )
                     else:
-                        media = []
-                case _:
-                    media = []
-            return media
+                        image = m["image_versions2"]["candidates"][0]
+                        media.append(
+                            ThreadsMedia(
+                                type=ThreadsMediaType.IMAGE,
+                                url=image["url"],
+                                thumb_url=image["url"],
+                                width=m.get("original_width", 0),
+                                height=m.get("original_height", 0),
+                            )
+                        )
+            case 19:  # 纯文本/外部链接
+                linked = (d.get("text_post_app_info") or {}).get("linked_inline_media")
+                media = cls._fetch_media(linked) if linked else []
+            case _:
+                media = []
+        return media
 
-        return fn(data)
+
+__all__ = [
+    "ThreadsAPI",
+    "ThreadsAPIError",
+    "ThreadsMedia",
+    "ThreadsMediaType",
+    "ThreadsPost",
+]


### PR DESCRIPTION
## Background

Threads walled off the old anonymous `/ajax/route-definition` trick the parser relied on: it now returns an empty preloader (`data.data: null`) with no media fields, so media fetching was effectively broken. Even the repo's own public test fixture (`@zaborona.magazine/post/DBuqMBwMfxW`) returns the generic `Threads` title with no media, and the raw response contains zero occurrences of `video_versions` / `image_versions2` / `carousel_media`.

## What changed

Rebuilt `ThreadsAPI` to mirror the existing `InstagramAPI` approach in this repo:

- **GraphQL fetch** — POST `/graphql/query` with a hardcoded `doc_id` (`BarcelonaPostPageDirectQuery`), authenticated via cookie + `x-csrftoken` (GETs `threads.com` to mint an anonymous `csrftoken` when none is configured). No `lsd`/`fb_dtsg` page-scraping needed.
- **Shortcode → `postID`** — decode the post shortcode to its numeric PK using the same base64 alphabet Instagram uses, and pass the required relay-provider variables.
- **Reused media parsing** — locate the target post in the returned `edges[]` by matching `code`, then run the existing `media_type` 1/2/8/19 logic against the post object.

The generic cookie plumbing (`SecretCookie`, the `parsehub set cookie <platform>` CLI, per-platform `cookies.toml`) already works, so no changes were needed there.

## Cookie behavior

- **Public posts** parse without a cookie (an anonymous `csrftoken` is minted automatically).
- **Login-walled posts** (private / restricted / age-gated) require a configured Cookie; without one they raise a clear "needs login" error. This matches how Instagram behaves in this repo.

## Tested samples

Verified live end-to-end through the public `ParseHub().parse()` API. "Login wall" = whether anonymous (no-cookie) access is blocked; every listed post was also downloaded to confirm the media URLs resolve.

| Post | Media type | Login wall? | Parsed result | Download |
|---|---|---|---|---|
| `@mu_chieh/Day_djOk6tM` | text (`19`) | 🔒 Yes | caption, 0 media | — (text-only) |
| `@yuzi_chan_/DazPhJ0mu6r` | image (`1`) | 🌐 No | 1 image, 666×1184 | ✅ 24.9 KB webp |
| `@yuehang_/Da2Cq6SoESy` | carousel (`8`) | 🌐 No | 3 images | ✅ 3× jpeg (~1.3 MB each) |
| `@tt.toast886/Da2ePsVjxoJ` | video (`2`) | 🌐 No | 1 video, 1276×720 | ✅ 4.1 MB mp4 |
| `@wuwin_dyd/Da3lxGjE6b_` | video via IG (`19`→`linked_inline_media`) | 🌐 No | 1 video, 720×1280 | ✅ 2.4 MB mp4 |
| `@konsatoshi631012/DaNHr6YidEX` | video (`2`) | 🔒 Yes | 1 video, 1080×1080 | ✅ 532 KB mp4 |

Every `media_type` branch (1 / 2 / 8 / 19, including the `19 → linked_inline_media` IG-crosspost path) is exercised against real posts with confirmed downloads. Login-walled posts without a cookie return the "needs login" error as expected.

## Checks

All passed locally:

| Command | Result |
|---|---|
| `pytest test/test_core_offline.py` | ✅ 21 passed, 77 subtests |
| `ruff check` | ✅ All checks passed |
| `ruff format --check` | ✅ Already formatted |
| `mypy` (changed files) | ✅ No issues found |

## Maintenance note

Like Instagram's hardcoded `doc_id`, the Threads `doc_id` and the relay-provider variable list can drift when Threads updates its web frontend, and may need periodic updates. The relay-provider variables are required by the query — passing only `postID` or a partial subset returns `execution error`.